### PR TITLE
updating public_ip resource based on allocation_method deprecation wa…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,7 @@ resource "azurerm_public_ip" "ptfe-pip" {
   name                         = "${var.demo_prefix}-ip"
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.ptfe.name}"
-  public_ip_address_allocation = "Dynamic"
+  allocation_method            = "Dynamic"
   domain_name_label            = "${var.hostname}"
 }
 


### PR DESCRIPTION
…rning from tf plan

Updating based on a deprecation warning TF plan printed to updated the public_ip_address_allocation to allocation_method for the azurerm_public_ip resource. 